### PR TITLE
Access complete account information

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,24 +57,12 @@ CBURL=https://127.0.0.1 // App Callback URL
 
 requests in this library are made through a `Handler()`, facilitated by an `Agent{}`. from here on out, the documentation assumes you have included the following code prior to making any requests:
 
-#### mac & windows
-
 ```
 import (
     "github.com/go-schwab/trader"
 )
 
 agent := trader.Initiate()
-```
-
-#### linux
-
-```
-import (
-    "github.com/go-schwab/trader"
-)
-
-agent := trader.InitiateLinux()
 ```
 
 ### 1.0 accessing market data

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ why should you use this project?
 
 ### 0.0 quick start
 
+#### mac & windows
+
 0. go to <https://developer.schwab.com>, create an account, create an app, get app credentials from <https://developer.schwab.com/dashboard/apps>
 1. create any file with the `.env` extension in your project directory (can also have multiple, if necessary), formatted as such:
 
@@ -36,11 +38,26 @@ openssl req -x509 -out localhost.crt -keyout localhost.key   -newkey rsa:2048 -n
 printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS.1:localhost,IP:127.0.0.1\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
 ```
 
-3. `go get github.com/go-schwab/trader@v0.9.0`
+3. `go get github.com/go-schwab/trader@v0.9.1`
+
+#### linux
+
+0. go to <https://developer.schwab.com>, create an account, create an app, get app credentials from <https://developer.schwab.com/dashboard/apps>
+1. create any file with the `.env` extension in your project directory (can also have multiple, if necessary), formatted as such:
+
+```
+APPKEY=KEY0 // App Key
+SECRET=KEY1 // App Secret
+CBURL=https://127.0.0.1 // App Callback URL
+```
+
+2. `go get github.com/go-schwab/trader@v0.9.1`
 
 ### 0.1 agent
 
-requests in this library are made through a `Handler()`, facilitated by an `Agent{}` created by calling: `agent := schwab.Initiate()`. from here on out, the documentation assumes you have included the following code prior to making any requests:
+requests in this library are made through a `Handler()`, facilitated by an `Agent{}`. from here on out, the documentation assumes you have included the following code prior to making any requests:
+
+#### mac & windows
 
 ```
 import (
@@ -48,6 +65,16 @@ import (
 )
 
 agent := trader.Initiate()
+```
+
+#### linux
+
+```
+import (
+    "github.com/go-schwab/trader"
+)
+
+agent := trader.InitiateLinux()
 ```
 
 ### 1.0 accessing market data

--- a/accounts-trading.go
+++ b/accounts-trading.go
@@ -82,6 +82,11 @@ type AccountNumbers struct {
 }
 
 type Account struct {
+	SecuritiesAccount       SecuritiesAccount
+	AggregatedBalance       AggregatedBalance
+}
+
+type SecuritiesAccount struct {
 	Type                    string
 	AccountNumber           string
 	RoundTrips              int
@@ -92,38 +97,38 @@ type Account struct {
 	InitialBalances         InitialBalance
 	CurrentBalances         CurrentBalance
 	ProjectedBalances       ProjectedBalance
-	AggregatedBalance       AggregatedBalance
 }
 
 type Position struct {
-	ShortQuantity                int
-	AveragePrice                 float64
-	CurrentDayProfitLoss         float64
-	LongQuantity                 int
-	SettledLongQuantity          int
-	SettledShortQuantity         int
-	AgedQuantity                 int
-	Instrument                   AccountInstrument
-	MarketValue                  float64
-	MaintenanceRequirement       float64
-	AverageLongPrice             float64
-	AverageShortPrice            float64
-	TaxLotAverageLongPrice       float64
-	TaxLotAverageShortPrice      float64
-	LongOpenProfitLoss           float64
-	ShortOpenProfitLoss          float64
-	PreviousSessionLongQuantity  int
-	PreviousSessionShortQuantity int
-	CurrentDayCost               float64
+	ShortQuantity                  float64
+	AveragePrice                   float64
+	CurrentDayProfitLoss           float64
+	CurrentDayProfitLossPercentage float64
+	LongQuantity                   float64
+	SettledLongQuantity            float64
+	SettledShortQuantity           float64
+	AgedQuantity                   float64
+	Instrument                     AccountInstrument
+	MarketValue                    float64
+	MaintenanceRequirement         float64
+	AverageLongPrice               float64
+	AverageShortPrice              float64
+	TaxLotAverageLongPrice         float64
+	TaxLotAverageShortPrice        float64
+	LongOpenProfitLoss             float64
+	ShortOpenProfitLoss            float64
+	PreviousSessionLongQuantity    float64
+	PreviousSessionShortQuantity   float64
+	CurrentDayCost                 float64
 }
 
 type AccountInstrument struct {
+	AssetType    string
 	Cusip        string
 	Symbol       string
 	Description  string
 	InstrumentID int
 	NetChange    float64
-	Type         string
 }
 
 type InitialBalance struct {
@@ -154,7 +159,7 @@ type InitialBalance struct {
 	ShortOptionMarketValue           float64
 	ShortStockValue                  float64
 	TotalCash                        float64
-	IsInCall                         float64
+	IsInCall                         bool
 	UnsettledCash                    float64
 	PendingDeposits                  float64
 	MarginBalance                    float64
@@ -184,13 +189,36 @@ type InitialBalance struct {
 	OptionBuyingPower                float64
 }*/
 
+
 type CurrentBalance struct {
-	AccruedInterest       float64
-	CashBalance           float64
-	CashReceipts          float64
-	LongOptionMarketValue float64
-	LiquidationValue      float64
-	SMA                   float64
+	AccruedInterest                  float64
+	CashBalance                      float64
+	CashReceipts                     float64
+	LongOptionMarketValue            float64
+	LiquidationValue                 float64
+	LongMarketValue                  float64
+	MoneyMarketFund                  float64
+	Savings                          float64
+	ShortMarketValue                 float64
+	PendingDeposits                  float64
+	MutualFundValues                 float64
+	BondValue                        float64
+	ShortOptionMarketValue           float64
+	AvailableFunds                   float64
+	AvailableFundsNonMarginableTrade float64
+	BuyingPower                      float64
+	BuyingPowerNonMarginableTrade    float64
+	DayTradingBuyingPower            float64
+	Equity                           float64
+	EquityPercentage                 float64
+	LongMarginValue                  float64
+	MaintenanceCall                  float64
+	MaintenanceRequirement           float64
+	MarginBalance                    float64
+	RegTCall                         float64
+	ShortBalance                     float64
+	ShortMarginValue                 float64
+	SMA                              float64
 }
 
 type ProjectedBalance struct {
@@ -210,7 +238,7 @@ type ProjectedBalance struct {
 	ShortBalance                     float64
 	ShortMarginValue                 float64
 	SMA                              float64
-	IsInCall                         float64
+	IsInCall                         bool
 	StockBuyingPower                 float64
 	OptionBuyingPower                float64
 }
@@ -548,11 +576,16 @@ func (agent *Agent) GetAccountNumbers() ([]AccountNumbers, error) {
 }
 
 // Get all accounts associated with the user logged in
-func (agent *Agent) GetAccounts() ([]Account, error) {
+func (agent *Agent) GetAccounts(fields ...string) ([]Account, error) {
+	var fieldsRequest string = strings.Join(fields, ",")
+
 	req, err := http.NewRequest("GET", endpointAccounts, nil)
 	if err != nil {
 		return []Account{}, err
 	}
+	q := req.URL.Query()
+	q.Add("fields", fieldsRequest)
+	req.URL.RawQuery = q.Encode()
 	resp, err := agent.Handler(req)
 	if err != nil {
 		return []Account{}, err
@@ -571,11 +604,16 @@ func (agent *Agent) GetAccounts() ([]Account, error) {
 }
 
 // Get account by encrypted account id
-func (agent *Agent) GetAccount(id string) (Account, error) {
+func (agent *Agent) GetAccount(id string, fields ...string) (Account, error) {
+	var fieldsRequest string = strings.Join(fields, ",")
+
 	req, err := http.NewRequest("GET", fmt.Sprintf(endpointAccount, id), nil)
 	if err != nil {
 		return Account{}, err
 	}
+	q := req.URL.Query()
+	q.Add("fields", fieldsRequest)
+	req.URL.RawQuery = q.Encode()
 	resp, err := agent.Handler(req)
 	if err != nil {
 		return Account{}, err

--- a/utils.go
+++ b/utils.go
@@ -193,8 +193,6 @@ func Initiate() *Agent {
 	switch runtime.GOOS {
 	case "linux":
 		linux = true
-	default:
-		log.Fatalf("Unsupported platform.")
 	}
 	isErrNil(err)
 	if linux {

--- a/utils.go
+++ b/utils.go
@@ -1,16 +1,24 @@
 package trader
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"time"
 
 	"github.com/bytedance/sonic"
 	o "github.com/go-schwab/utils/oauth"
@@ -18,7 +26,18 @@ import (
 	"golang.org/x/oauth2"
 )
 
-type Agent struct{ *o.AuthorizedClient }
+type Agent struct {
+	Client *o.AuthorizedClient
+	Tokens Token
+	Linux  bool
+}
+
+type Token struct {
+	RefreshExpiration time.Time
+	Refresh           string
+	BearerExpiration  time.Time
+	Bearer            string
+}
 
 var (
 	APPKEY string
@@ -41,6 +60,32 @@ func isErrNil(err error) {
 	}
 }
 
+// trim one FIRST & one LAST character in the string
+func trimOneFirstOneLast(s string) string {
+	if len(s) < 1 {
+		return ""
+	}
+	return s[1 : len(s)-1]
+}
+
+// Helper: parse access token response
+func parseAccessTokenResponse(s string) Token {
+	token := Token{
+		RefreshExpiration: time.Now().Add(time.Hour * 168),
+		BearerExpiration:  time.Now().Add(time.Minute * 30),
+	}
+	for _, x := range strings.Split(s, ",") {
+		for i1, x1 := range strings.Split(x, ":") {
+			if trimOneFirstOneLast(x1) == "refresh_token" {
+				token.Refresh = trimOneFirstOneLast(strings.Split(x, ":")[i1+1])
+			} else if trimOneFirstOneLast(x1) == "access_token" {
+				token.Bearer = trimOneFirstOneLast(strings.Split(x, ":")[i1+1])
+			}
+		}
+	}
+	return token
+}
+
 // find all env files
 func findAllEnvFiles() []string {
 	var files []string
@@ -58,6 +103,57 @@ func findAllEnvFiles() []string {
 	})
 	isErrNil(err)
 	return files
+}
+
+// Credit: https://gist.github.com/hyg/9c4afcd91fe24316cbf0
+func openBrowser(url string) {
+	var err error
+	switch runtime.GOOS {
+	case "linux":
+		err = exec.Command("xdg-open", url).Start()
+	case "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		err = exec.Command("open", url).Start()
+	default:
+		log.Fatalf("Unsupported platform.")
+	}
+	isErrNil(err)
+}
+
+// Execute a command @ stdin, receive stdout
+func execCommand(cmd *exec.Cmd) {
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	err := cmd.Run()
+
+	if err != nil {
+		log.Fatalf(err.Error())
+	}
+}
+
+// Read in tokens from .json
+func readLinuxDB() Token {
+	var tokens Token
+	body, err := os.ReadFile(".json")
+	isErrNil(err)
+	err = json.Unmarshal(body, &tokens)
+	isErrNil(err)
+	return tokens
+}
+
+// Credit: https://go.dev/play/p/C2sZRYC15XN
+func getStringInBetween(str string, start string, end string) (result string) {
+	s := strings.Index(str, start)
+	if s == -1 {
+		return
+	}
+	s += len(start)
+	e := strings.Index(str[s:], end)
+	if e == -1 {
+		return
+	}
+	return str[s : s+e]
 }
 
 // Read in tokens from .json
@@ -81,26 +177,91 @@ func readDB() Agent {
 	sslcli := &http.Client{Transport: tr}
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, sslcli)
 	return Agent{
-		&o.AuthorizedClient{
+		Client: &o.AuthorizedClient{
 			conf.Client(ctx, tok),
 			tok,
 		},
 	}
 }
 
+// FOR LINUX USERS
+func InitiateLinux() *Agent {
+	var agent Agent
+	if _, err := os.Stat(".json"); errors.Is(err, os.ErrNotExist) {
+		// oAuth Leg 1 - Authorization Code
+		openBrowser(fmt.Sprintf("https://api.schwabapi.com/v1/oauth/authorize?client_id=%s&redirect_uri=%s", os.Getenv("APPKEY"), os.Getenv("CBURL")))
+		fmt.Printf("Log into your Schwab brokerage account. Copy Error404 URL and paste it here: ")
+		var urlInput string
+		fmt.Scanln(&urlInput)
+		authCodeEncoded := getStringInBetween(urlInput, "?code=", "&session=")
+		authCode, err := url.QueryUnescape(authCodeEncoded)
+		isErrNil(err)
+		// oAuth Leg 2 - Refresh, Bearer Tokens
+		authStringLegTwo := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", os.Getenv("APPKEY"), os.Getenv("SECRET")))))
+		client := http.Client{}
+		payload := fmt.Sprintf("grant_type=authorization_code&code=%s&redirect_uri=%s", string(authCode), os.Getenv("CBURL"))
+		req, err := http.NewRequest("POST", "https://api.schwabapi.com/v1/oauth/token", bytes.NewBuffer([]byte(payload)))
+		isErrNil(err)
+		req.Header = http.Header{
+			"Authorization": {authStringLegTwo},
+			"Content-Type":  {"application/x-www-form-urlencoded"},
+		}
+		res, err := client.Do(req)
+		isErrNil(err)
+		defer res.Body.Close()
+		bodyBytes, err := io.ReadAll(res.Body)
+		isErrNil(err)
+		agent.Tokens = parseAccessTokenResponse(string(bodyBytes))
+		bytes, err := sonic.Marshal(agent.Tokens)
+		isErrNil(err)
+		err = os.WriteFile(".json", bytes, 0777)
+		isErrNil(err)
+	} else {
+		agent.Tokens = readLinuxDB()
+		if agent.Tokens.Bearer == "" {
+			err := os.Remove(".json")
+			isErrNil(err)
+			log.Fatalf("[err] please reinitiate, something went wrong\n")
+		}
+	}
+	agent.Linux = true
+	return &agent
+}
+
+// FOR MAC, WINDOWS USERS
 func Initiate() *Agent {
 	var agent Agent
-	// TODO: test this block, this is to attempt to resolve the error described in #67
 	if _, err := os.Stat(".json"); errors.Is(err, os.ErrNotExist) {
-		agent = Agent{o.Initiate(APPKEY, SECRET)}
-		bytes, err := sonic.Marshal(agent.Token)
+		//execCommand("openssl req -x509 -out localhost.crt -keyout localhost.key   -newkey rsa:2048 -nodes -sha256   -subj '/CN=localhost' -extensions EXT -config <(;printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS.1:localhost,IP:127.0.0.1\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")")
+		agent = Agent{Client: o.Initiate(APPKEY, SECRET)}
+		bytes, err := sonic.Marshal(agent.Client.Token)
 		isErrNil(err)
 		err = os.WriteFile(".json", bytes, 0777)
 		isErrNil(err)
 	} else {
 		agent = readDB()
 	}
+	agent.Linux = false
 	return &agent
+}
+
+// Use refresh token to generate a new bearer token for authentication
+func (agent *Agent) refresh() {
+	oldTokens := readLinuxDB()
+	authStringRefresh := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", os.Getenv("APPKEY"), os.Getenv("SECRET")))))
+	client := http.Client{}
+	req, err := http.NewRequest("POST", "https://api.schwabapi.com/v1/oauth/token", bytes.NewBuffer([]byte(fmt.Sprintf("grant_type=refresh_token&refresh_token=%s", oldTokens.Refresh))))
+	isErrNil(err)
+	req.Header = http.Header{
+		"Authorization": {authStringRefresh},
+		"Content-Type":  {"application/x-www-form-urlencoded"},
+	}
+	res, err := client.Do(req)
+	isErrNil(err)
+	defer res.Body.Close()
+	bodyBytes, err := io.ReadAll(res.Body)
+	isErrNil(err)
+	agent.Tokens = parseAccessTokenResponse(string(bodyBytes))
 }
 
 // Handler is the general purpose request function for the td-ameritrade api, all functions will be routed through this handler function, which does all of the API calling work
@@ -109,23 +270,51 @@ func Initiate() *Agent {
 // It takes one parameter:
 // req = a request of type *http.Request
 func (agent *Agent) Handler(req *http.Request) (*http.Response, error) {
-	var err error
-	if agent.Token.AccessToken == "" {
-		log.Fatal("[fatal] no access token found, please reinitiate with 'Initiate'")
-		// TODO: auto reinitiate?
-	}
-	resp, err := agent.Do(req)
-	if err != nil {
-		return resp, err
-	}
-	switch true {
-	case resp.StatusCode == 401:
-		log.Fatal("[fatal] invalid token - please reinitiate with 'Initiate'")
-	case resp.StatusCode < 200, resp.StatusCode > 300:
-		defer resp.Body.Close()
-		body, err := io.ReadAll(resp.Body)
+	if agent.Linux {
+		if (&Agent{}) == agent {
+			log.Fatal("[fatal] empty agent - call 'Agent.Initiate' before making any API function calls.")
+			// TODO: auto reinitiate?
+		}
+		if !time.Now().Before(agent.Tokens.BearerExpiration) {
+			agent.refresh()
+		}
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", agent.Tokens.Bearer))
+		client := http.Client{}
+		resp, err := client.Do(req)
 		isErrNil(err)
-		log.Println("[err] ", string(body))
+		switch true {
+		case resp.StatusCode == 200:
+			return resp, nil
+		case resp.StatusCode == 401:
+			log.Fatal("[fatal] invalid token - please reinitiate with 'Initiate'")
+			// TODO: auto reinitiate?
+		case resp.StatusCode < 200, resp.StatusCode > 300:
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			isErrNil(err)
+			log.Println("[err] ", string(body))
+		}
+	} else {
+		if agent.Client.Token.AccessToken == "" {
+			log.Fatal("[fatal] no access token found, please reinitiate with 'Initiate'")
+			// TODO: auto reinitiate?
+		}
+		resp, err := agent.Client.Do(req)
+		if err != nil {
+			return resp, err
+		}
+		switch true {
+		case resp.StatusCode == 200:
+			return resp, nil
+		case resp.StatusCode == 401:
+			log.Fatal("[fatal] invalid token - please reinitiate with 'Initiate'")
+			// TODO: auto reinitiate?
+		case resp.StatusCode < 200, resp.StatusCode > 300:
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			isErrNil(err)
+			log.Println("[err] ", string(body))
+		}
 	}
-	return resp, nil
+	return nil, nil
 }


### PR DESCRIPTION
major:
ref: #72  
desc: Accesses complete account information by aligning the structs to what is currently returned by the api. Adds support for the fields= parameter which allows for GetAccount() or GetAccounts() to specify "positions."

Quick code to pull accounts and position informtion
```
acs, err := agent.GetAccounts("positions")
if err != nil {
	fmt.Println(err)
}
for _, ac := range acs {
	fmt.Printf("Account: %s\n", ac.SecuritiesAccount.AccountNumber)
	for _, position := range ac.SecuritiesAccount.Positions {
		quote, err := agent.GetQuote(position.Instrument.Symbol)
		var mark = 0.00
		if err == nil {
			switch quote.AssetMainType {
			case "MUTUAL_FUND":
				mark = quote.Close
			default:
				mark = quote.Mark
			}
		}	
		fmt.Printf(" %s %.4f @ $%.2f $%.2f\n", position.Instrument.Symbol, position.LongQuantity, mark, position.MarketValue)
	}
}
```
